### PR TITLE
fix: Run openscad with xvfb

### DIFF
--- a/src/stl_generator/__init__.py
+++ b/src/stl_generator/__init__.py
@@ -32,6 +32,8 @@ def stl_to_png(path_stl, f_png):
         f_scad.flush()
         subprocess.check_call(
             [
+                "xvfb-run",
+                "-a",
                 "openscad",
                 f_scad.name,
                 "-o",


### PR DESCRIPTION
Use a virtual framebuffer for png rendering on servers as openscad relies on the x-org framebuffer for rendering.
see https://github.com/openscad/openscad/issues/3983